### PR TITLE
Changing the composer specifications to 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "drupal/calendar": "*",
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/console": "^1.0.1",
-        "drupal/core": "~8.0",
+        "drupal/core": "~8.4",
         "drupal/commerce": "~2.0",
         "drupal/swiftmailer": "~1.0",
         "drupal/token": "~1.0",


### PR DESCRIPTION
Drupal 8.5 is not ready to be tested, so for now we'd like to keep it at 8.4